### PR TITLE
fix geometry bug exposed by trying to load wrf files

### DIFF
--- a/tests/test_accesor.py
+++ b/tests/test_accesor.py
@@ -176,3 +176,9 @@ def test_coord_aliasing():
     ds_yt = ds.yt.load_uniform_grid([fld], length_unit="km")
     f = ds_yt.all_data()[("stream", fld)]
     assert len(f) == ds.data_vars[fld].size
+
+
+def test_geom_kwarg(ds_xr):
+    # make sure we can specify the geometry
+    flds = ["a_new_field_0", "a_new_field_1"]
+    _ = ds_xr.yt.load_uniform_grid(fields=flds, geometry="cartesian")

--- a/yt_xarray/accessor/accessor.py
+++ b/yt_xarray/accessor/accessor.py
@@ -38,8 +38,8 @@ class YtAccessor:
         )
 
         if geometry is None:
-            geomtype = _determine_yt_geomtype(self.coord_type, sel_info.selected_coords)
-            if geomtype is None:
+            geometry = _determine_yt_geomtype(self.coord_type, sel_info.selected_coords)
+            if geometry is None:
                 raise ValueError(
                     "Cannot determine yt geometry type, please provide"
                     "geometry = 'geographic', 'internal_geopgraphic' or 'cartesian'"
@@ -58,7 +58,7 @@ class YtAccessor:
                     "a keyword argument."
                 )
 
-        geom = (geomtype, sel_info.yt_coord_names)
+        geom = (geometry, sel_info.yt_coord_names)
         print(geom)
 
         simtime = sel_info.selected_time


### PR DESCRIPTION
Tried to load a wrf file, found that the `geometry` keyword argument was not actually being used by `_load_uniform_grid`